### PR TITLE
legacy: Define SZ.

### DIFF
--- a/firmware_axoloti_legacy/flasher/Makefile
+++ b/firmware_axoloti_legacy/flasher/Makefile
@@ -154,6 +154,7 @@ LD   = $(TRGT)gcc
 CP   = $(TRGT)objcopy
 AS   = $(TRGT)gcc -x assembler-with-cpp
 OD   = $(TRGT)objdump
+SZ   = $(TRGT)size
 HEX  = $(CP) -O ihex
 BIN  = $(CP) -O binary
 

--- a/firmware_axoloti_legacy/mounter/Makefile
+++ b/firmware_axoloti_legacy/mounter/Makefile
@@ -150,6 +150,7 @@ LD   = $(TRGT)gcc
 CP   = $(TRGT)objcopy
 AS   = $(TRGT)gcc -x assembler-with-cpp
 OD   = $(TRGT)objdump
+SZ   = $(TRGT)size
 HEX  = $(CP) -O ihex
 BIN  = $(CP) -O binary
 


### PR DESCRIPTION
When `USE_VERBOSE_COMPILE` is `no`,
`chibios/os/ports/GCC/ARMCMx/rules.mk` uses `$(SZ)` on the generated mounte and flasher binaries.  The `SZ` variable, however, is undefined and so `make` ends up attempting to execute the cross-built binaries on the host.