### PR TITLE
Initialize LibUsb context before using it.

### DIFF
--- a/src/main/java/axoloti/dialogs/USBPortSelectionDlg.java
+++ b/src/main/java/axoloti/dialogs/USBPortSelectionDlg.java
@@ -166,7 +166,14 @@ public class USBPortSelectionDlg extends javax.swing.JDialog {
         DefaultTableModel model = (DefaultTableModel) jTable1.getModel();
         model.setRowCount(0);
         DeviceList list = new DeviceList();
-        int result = LibUsb.getDeviceList(null, list);
+
+        int result = LibUsb.init(null);
+
+        if (result < 0) {
+            throw new LibUsbException("Unable to initialize LibUsb context", result);
+        }
+
+        result = LibUsb.getDeviceList(null, list);
 
         if (result < 0) {
             throw new LibUsbException("Unable to get device list", result);


### PR DESCRIPTION
getDeviceList can only be invoked after initializing LibUsb.  This may happen incidentally during other operations, but it is not guaranteed that LibUsb is initialized when USBPortSelectionDlg is populated.

(Initializing LibUsb more than once is not a problem.)